### PR TITLE
Disable logging credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,18 @@ const cache = new Map();
 const CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // Cache for 30 Days
 
 if (config.challenge !== false) {
-  console.log(
-    chalk.green("🔒 Password protection is enabled! Listing logins below"),
-  );
-  // biome-ignore lint/complexity/noForEach:
-  Object.entries(config.users).forEach(([username, password]) => {
-    console.log(chalk.blue(`Username: ${username}, Password: ${password}`));
-  });
+  console.log(chalk.green("🔒 Password protection is enabled!"));
+  if (process.env.LOG_CREDENTIALS === "true") {
+    console.warn(
+      chalk.yellow(
+        "⚠️  LOG_CREDENTIALS is enabled. Usernames and passwords will be logged.",
+      ),
+    );
+    // biome-ignore lint/complexity/noForEach:
+    Object.entries(config.users).forEach(([username, password]) => {
+      console.log(chalk.blue(`Username: ${username}, Password: ${password}`));
+    });
+  }
   app.use(basicAuth({ users: config.users, challenge: true }));
 }
 


### PR DESCRIPTION
## Summary
- stop default printing of usernames/passwords in `index.js`
- allow optional logging when `LOG_CREDENTIALS=true`

## Testing
- `npm run format`
- `npm run lint` *(fails: lint errors in unmodified files)*

------
https://chatgpt.com/codex/tasks/task_e_68405201d04883339706f9eb81191d85