### PR TITLE
Update branding colors and fonts

### DIFF
--- a/static/assets/css/error.css
+++ b/static/assets/css/error.css
@@ -1,6 +1,6 @@
 .error {
    color: var(--text-primary);
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    font-weight: 900;
    top: 15%;
    text-align: center;
@@ -9,7 +9,7 @@
 .error h1 {
    font-size: 10vw;
    margin: 0 auto -2vw auto;
-   background: linear-gradient(150deg, #746eff 0%, #ff00bb 51%, #746eff 100%);
+   background: linear-gradient(150deg, #00274c 0%, #ffcb05 51%, #00274c 100%);
    -webkit-background-clip: text;
    -moz-background-clip: text;
    background-clip: text;

--- a/static/assets/css/global.css
+++ b/static/assets/css/global.css
@@ -1,25 +1,24 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap");
 
 :root {
    /* Background Variables */
    --background-image: url("/./assets/media/background/full-main.png"); /* Background Image */
    --backdrop-filter: blur(10px) brightness(80%); /* Nav Backdrop filter */
-   --background-nav: rgba(255, 255, 255, 0.02); /* Nav Background */
-   --background-color: #222; /* Main Background Color */
-   --background-input: #4545459e; /* Input Field Background Color */
-   --background-column: #353535; /* Background for Apps Container */
-   --background-settings: #2a2a2a; /* Settings Card Background */
-   --background-buttons: #333; /* Button Background Color */
-   --tab-active-background: #444; /* Accent Color for Tabs */
+   --background-nav: #00274c; /* Nav Background */
+   --background-color: #00274c; /* Main Background Color */
+   --background-input: #003865; /* Input Field Background Color */
+   --background-column: #013369; /* Background for Apps Container */
+   --background-settings: #003865; /* Settings Card Background */
+   --background-buttons: #013369; /* Button Background Color */
+   --tab-active-background: #ffcb05; /* Accent Color for Tabs */
    --tab-inactive-background: ; /* Background Color for Tabs Not In Use */
-   --slider-active-background: #4caf50; /* Active Slider Background Color */
-   --slider-inactive-background: #ccc; /*  Slider Background Color */
+   --slider-active-background: #ffcb05; /* Active Slider Background Color */
+   --slider-inactive-background: #00274c; /*  Slider Background Color */
    --nav-image: url("/./assets/media/favicon/main.png"); /* Nav Logo */
    /* Text Variables */
-   --text-primary: #fff; /* Primary Text Color */
-   --text-dark: #555; /* Dark Text Color for Error Page, Scrollbar, and Particles */
-   --text-placeholder: #aaa; /* Placeholder Text Color */
+   --text-primary: #ffcb05; /* Primary Text Color */
+   --text-dark: #00274c; /* Dark Text Color for Error Page, Scrollbar, and Particles */
+   --text-placeholder: #ffcb05; /* Placeholder Text Color */
    /* Other Variables */
    --save-button: #4caf50; /* Save Button, Typically Green */
    --reset-button: #f44336; /* Reset Button, Typically Red */
@@ -49,7 +48,7 @@
 }
 
 body {
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    text-decoration: none;
    background: var(--background-image);
    height: 100%;
@@ -66,7 +65,7 @@ body {
 
 .main {
    letter-spacing: 0px;
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    width: 99%;
    display: flex;
    flex-direction: column;

--- a/static/assets/css/h.css
+++ b/static/assets/css/h.css
@@ -7,7 +7,7 @@
 .title {
    font-size: 10vh;
    color: var(--text-primary);
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    text-align: center;
    text-transform: uppercase;
    border-radius: 0px 0px 5px 5px;
@@ -28,7 +28,7 @@
       top: -10vw;
       font-size: 10vw;
       color: var(--text-primary);
-      font-family: "Inter", sans-serif;
+      font-family: "Roboto", sans-serif;
       text-align: center;
       text-transform: uppercase;
       border-radius: 0px 0px 5px 5px;
@@ -46,7 +46,7 @@
 .search-home {
    width: 50vw;
    height: 5vh;
-   font-family: "Poppins", sans-serif;
+   font-family: "Roboto", sans-serif;
    font-size: 16px;
    box-shadow: 0 0 15px 2px rgba(0, 0, 0, 0.2);
    background: var(--background-input);
@@ -94,5 +94,5 @@ input {
    margin-bottom: 1em;
    margin-top: -2em;
    padding: 0;
-   font-family: "Poppins", sans-serif;
+   font-family: "Roboto", sans-serif;
 }

--- a/static/assets/css/nav.css
+++ b/static/assets/css/nav.css
@@ -50,7 +50,7 @@ img {
    float: left;
    text-transform: uppercase;
    font-size: 30px;
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    cursor: pointer;
    color: var(--text-primary);
    font-weight: 600;
@@ -80,7 +80,7 @@ img {
    color: var(--text-primary);
    font-weight: 800;
    right: 2%;
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    font-style: normal;
    text-decoration: none;
    transition: all 0.2s ease;
@@ -96,7 +96,7 @@ img {
       color: var(--text-primary);
       font-weight: 800;
       right: 2%;
-      font-family: "Inter", sans-serif;
+      font-family: "Roboto", sans-serif;
       font-style: normal;
       text-decoration: none;
       transition: all 0.2s ease;
@@ -106,7 +106,7 @@ img {
       text-transform: uppercase;
       cursor: pointer;
       font-weight: 800;
-      font-family: "Inter", sans-serif;
+      font-family: "Roboto", sans-serif;
       font-style: normal;
       font-size: 3vw;
       transform: translateX(-20%);
@@ -117,7 +117,7 @@ img {
    text-transform: uppercase;
    cursor: pointer;
    font-weight: 800;
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    font-style: normal;
    font-size: 3vh;
    transform: translateX(-20%);

--- a/static/assets/css/settings.css
+++ b/static/assets/css/settings.css
@@ -1,6 +1,6 @@
 body {
    background-color: var(--background-image);
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    color: var(--text-primary);
    margin: 0;
    padding: 0;

--- a/static/assets/css/t.css
+++ b/static/assets/css/t.css
@@ -1,8 +1,7 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
 
 body {
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    text-decoration: none;
    margin: 0;
    overflow-x: hidden;
@@ -103,7 +102,7 @@ body {
    text-transform: uppercase;
    cursor: pointer;
    font-weight: 800;
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    font-style: normal;
    font-size: 3vw;
    transform: translateX(-20%);
@@ -113,7 +112,7 @@ body {
    text-transform: uppercase;
    cursor: pointer;
    font-weight: 800;
-   font-family: "Inter", sans-serif;
+   font-family: "Roboto", sans-serif;
    font-style: normal;
    font-size: 3vh;
    transform: translateX(-20%);


### PR DESCRIPTION
## Summary
- rebrand UI using maize and blue scheme
- use Roboto font across the site
- tweak error header gradient

## Testing
- `npm run format`
- `npx biome check --write .` *(fails: complexity/noForEach in config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68408a3833d48333b4425d9016136a40