### PR TITLE
Fix games JSON path detection

### DIFF
--- a/static/assets/js/002.js
+++ b/static/assets/js/002.js
@@ -1,6 +1,7 @@
 // c.js
 let appInd;
-const g = window.location.pathname === "/a";
+const g =
+  window.location.pathname === "/a" || window.location.pathname === "/play.html";
 const a = window.location.pathname === "/b";
 const c = window.location.pathname === "/gt";
 


### PR DESCRIPTION
## Summary
- detect `/play.html` path when loading games JSON so `/a` and `/play.html` behave identically

## Testing
- `pnpm exec biome lint .` *(fails: Prefer for...of instead of forEach)*
- `npm test` *(fails: Missing script: "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68408a23d93483338fb23364ea03360d