### PR TITLE
Fix Ultraviolet naming in settings

### DIFF
--- a/static/settings.html
+++ b/static/settings.html
@@ -173,12 +173,12 @@
       <div class="settings-card">
         <h3>Choose your <an>Pro</an>xy</h3>
         <p>
-          Ultra<an>vio</an>let is the main <an>pro</an>xy, but Dynamic is
-          faster and supports more sites. (Dynamic is still in beta, so expect
-          some bugs.)
+          starlancer built by Arjun and codex o3 is the main <an>pro</an>xy,
+          but Dynamic is faster and supports more sites. (Dynamic is still in
+          beta, so expect some bugs.)
         </p>
         <select id="pChange">
-          <option value="uv">Ultra<an>vio</an>let (Default)</option>
+          <option value="uv">starlancer built by Arjun and codex o3 (Default)</option>
           <option value="dy">Dynamic (Doesn't work in about:blank)</option>
         </select>
       </div>


### PR DESCRIPTION
## Summary
- rename Ultraviolet proxy mention in the settings UI

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_6840c36806748333b4c99faad6db23c8