### PR TITLE
Enable Node cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ Whether you run Starlancer once or make it a daily companion, thank you for givi
 We hope it earns a spot in your toolkit — and we can’t wait to see what you build next.
 
 *— Arjun & Codex o3*
+
+## Running with Multiple Workers
+
+Starlancer can utilize Node's built‑in clustering to take advantage of
+multiple CPU cores. Use the provided script to spin up several workers:
+
+```bash
+# defaults to the number of CPU cores
+pnpm run start:cluster
+
+# or specify how many workers to launch
+WORKERS=4 pnpm run start:cluster
+```
+
+Each worker maintains its own in‑memory cache and continues to rely on cookie
+based authentication. No shared state is required, so sessions and cached
+assets work the same way whether you run one worker or many.

--- a/cluster.js
+++ b/cluster.js
@@ -1,0 +1,21 @@
+import cluster from 'node:cluster';
+import os from 'node:os';
+
+const numWorkers = Number.parseInt(process.env.WORKERS || os.cpus().length, 10);
+
+if (cluster.isPrimary) {
+  console.log(`Primary ${process.pid} is running`);
+
+  for (let i = 0; i < numWorkers; i++) {
+    cluster.fork();
+  }
+
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(
+      `Worker ${worker.process.pid} died with code ${code || 'unknown'} and signal ${signal || 'none'}. Restarting.`,
+    );
+    cluster.fork();
+  });
+} else {
+  await import('./index.js');
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node index.js",
+    "start:cluster": "node cluster.js",
     "format": "biome format --write .",
     "precommit": "pnpm run format && biome check --write .",
     "lint": "biome lint --write ."


### PR DESCRIPTION
## Summary
- add a small cluster runner using Node's built-in cluster module
- document how to launch multiple workers
- expose a `start:cluster` script in `package.json`

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840c48feffc8333911cfc95d9ff0a94