### PR TITLE
Add rate limiting and configurable CORS

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,3 +35,10 @@ By keeping your site up to date, you not only enjoy the latest features but also
 If you encounter any challenges while updating, feel free to reach out to our [support team](https://discord.gg/starlancer) for assistance.
 
 Thank you for prioritizing the security and performance of your experience with our site.
+
+### Request Throttling and Trusted CORS
+
+The application limits repeated requests from the same IP address using
+`express-rate-limit`. Allowed CORS origins are defined through the
+`TRUSTED_ORIGINS` environment variable. Requests from other origins are
+rejected.

--- a/config.js
+++ b/config.js
@@ -4,4 +4,4 @@ dotenv.config();
 
 function parseUsers(value) {
   const users = {};
-};
+}

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 import basicAuth from "express-basic-auth";
+import rateLimit from "express-rate-limit";
 import mime from "mime";
 import fetch from "node-fetch";
 // import { setupMasqr } from "./Masqr.js";
@@ -19,6 +20,25 @@ const server = http.createServer();
 const app = express();
 const bareServer = createBareServer("/ca/");
 const PORT = process.env.PORT || 8080;
+const trustedOrigins = (process.env.TRUSTED_ORIGINS || "")
+  .split(",")
+  .map(origin => origin.trim())
+  .filter(Boolean);
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || trustedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error("Not allowed by CORS"));
+    }
+  },
+};
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 const cache = new Map();
 const CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // Cache for 30 Days
 const CACHE_MAX_ENTRIES = 100; // Maximum number of cached items
@@ -101,6 +121,7 @@ app.get("/e/*", async (req, res, next) => {
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(limiter);
 
 /* if (process.env.MASQR === "true") {
   console.log(chalk.green("Masqr is enabled"));
@@ -108,7 +129,7 @@ app.use(express.urlencoded({ extended: true }));
 } */
 
 app.use(express.static(path.join(__dirname, "static")));
-app.use("/ca", cors({ origin: true }));
+app.use("/ca", cors(corsOptions));
 
 const routes = [
   { path: "/b", file: "apps.html" },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "express-basic-auth": "^1.2.1",
+    "express-rate-limit": "^7.5.0",
     "mime": "^4.0.7",
     "node-fetch": "^3.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       express-basic-auth:
         specifier: ^1.2.1
         version: 1.2.1
+      express-rate-limit:
+        specifier: ^7.5.0
+        version: 7.5.0(express@4.21.2)
       mime:
         specifier: ^4.0.7
         version: 4.0.7
@@ -221,6 +224,12 @@ packages:
 
   express-basic-auth@1.2.1:
     resolution: {integrity: sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==}
+
+  express-rate-limit@7.5.0:
+    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: ^4.11 || 5 || ^5.0.0-beta.1
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -601,6 +610,10 @@ snapshots:
   express-basic-auth@1.2.1:
     dependencies:
       basic-auth: 2.0.1
+
+  express-rate-limit@7.5.0(express@4.21.2):
+    dependencies:
+      express: 4.21.2
 
   express@4.21.2:
     dependencies:


### PR DESCRIPTION
## Summary
- add express-rate-limit dependency
- throttle requests per IP in server
- allow CORS only from origins listed in TRUSTED_ORIGINS env var
- document new protections in SECURITY.md

## Testing
- `pnpm run format`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840c48c1e0c8333a710b7af5aa70687