### PR TITLE
Rebrand only the index page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,7 +20,7 @@
   <div id="particles-js">
     <script rel="preload" src="https://cdn.jsdelivr.net/particles.js/2.0.0/"></script>
     <div class="main">
-      <h1 class="title">&#73;&#110;&#116;&#101;&#114;&#115;&#116;&#101;&#108;&#108;&#97;&#114;</h1>
+      <h1 class="title">&#83;&#116;&#97;&#114;&#108;&#97;&#110;&#99;&#101;&#114;</h1>
       <p id="splash"></p>
       <div class="search-container">
         <form id="fv" method="POST">


### PR DESCRIPTION
## Summary
- revert README changes so Interstellar references remain
- keep the index page title branded as Starlancer

## Testing
- `pnpm run lint` *(fails: biome not found)*
- `pnpm run format` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d7157eac8333b9d62f50eef18fce