### PR TITLE
Break Google tracking

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="/assets/css/error.css?v=2" />
   <link rel="stylesheet" href="/assets/css/nav.css?v=01" />
   <script src="assets/js/003.js?v=000"></script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6840529569014734"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-68405295690147341"
     crossorigin="anonymous"></script>
 
 </head>

--- a/static/apps.html
+++ b/static/apps.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="/assets/css/nav.css?v=01" />
   <script src="/assets/js/005.js?v=000"></script>
   <script src="assets/js/003.js?v=000"></script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6840529569014734"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-68405295690147341"
     crossorigin="anonymous"></script>
 
 </head>
@@ -45,7 +45,7 @@
   <div class="apps"></div>
   <script src="assets/js/002.js?v=001"></script>
   <script src="/assets/js/001.js?v=001"></script>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
   <!-- DO NOT REMOVE-->
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -54,7 +54,7 @@
     }
     gtag("js", new Date());
 
-    gtag("config", "G-WKJQ5QHQTJ");
+    gtag("config", "G-WKJQ5QHQTJ1");
   </script>
   <!-- DO NOT REMOVE-->
 </body>

--- a/static/games.html
+++ b/static/games.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="/assets/css/container.css?v=2" />
   <link rel="stylesheet" href="/assets/css/nav.css?v=01" />
   <script src="/assets/js/005.js?v=000"></script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6840529569014734"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-68405295690147341"
     crossorigin="anonymous"></script>
 
 </head>
@@ -40,7 +40,7 @@
   <script src="./assets/mathematics/config.js?v=2025-04-15"></script>
   <script src="assets/js/003.js?v=000"></script>
   <script src="/assets/js/001.js?v=001"></script>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
   <!-- DO NOT REMOVE-->
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -49,7 +49,7 @@
     }
     gtag("js", new Date());
 
-    gtag("config", "G-WKJQ5QHQTJ");
+    gtag("config", "G-WKJQ5QHQTJ1");
   </script>
   <!-- DO NOT REMOVE-->
 </body>

--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/assets/css/global.css?v=6" />
   <link rel="stylesheet" href="/assets/css/h.css?v=01" />
   <link rel="stylesheet" href="/assets/css/nav.css?v=01" />
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6840529569014734"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-68405295690147341"
     crossorigin="anonymous"></script>
 </head>
 
@@ -36,7 +36,7 @@
   <script src="assets/js/003.js?v=000"></script>
   <script src="/assets/js/001.js?v=001"></script>
   <!-- DO NOT REMOVE-->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
   <script>
     window.dataLayer = window.dataLayer || []
     function gtag() {
@@ -44,7 +44,7 @@
     }
     gtag("js", new Date())
 
-    gtag("config", "G-WKJQ5QHQTJ")
+    gtag("config", "G-WKJQ5QHQTJ1")
   </script>
   <!-- DO NOT REMOVE-->
 </body>

--- a/static/settings.html
+++ b/static/settings.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="/assets/css/nav.css?v=01" />
   <link rel="stylesheet" href="/assets/css/settings.css?v=06" />
   <script src="assets/js/003.js?v=000"></script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6840529569014734"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-68405295690147341"
     crossorigin="anonymous"></script>
 
 </head>
@@ -238,7 +238,7 @@
   <script src="/assets/js/001.js?v=001"></script>
   <script src="/assets/js/006.js?v=000"></script>
   <!-- DO NOT REMOVE-->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() {
@@ -246,7 +246,7 @@
     }
     gtag("js", new Date());
 
-    gtag("config", "G-WKJQ5QHQTJ");
+    gtag("config", "G-WKJQ5QHQTJ1");
   </script>
   <!-- DO NOT REMOVE-->
 </body>

--- a/static/tabs.html
+++ b/static/tabs.html
@@ -65,7 +65,7 @@
   <script src="./assets/mathematics/config.js?v=2025-04-15"></script>
   <script src="/assets/js/001.js?v=001"></script>
   <!-- DO NOT REMOVE-->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() {
@@ -73,7 +73,7 @@
     }
     gtag("js", new Date());
 
-    gtag("config", "G-WKJQ5QHQTJ");
+    gtag("config", "G-WKJQ5QHQTJ1");
   </script>
   <!-- DO NOT REMOVE-->
 </body>


### PR DESCRIPTION
## Summary
- break Google Ads and Tag Manager keys by appending `1`
- run `pnpm run lint` (fails due to Biome issues)

## Testing
- `pnpm run lint` *(fails: Some errors were emitted)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc27dc648333a37e0f9bbc65c503