### PR TITLE
Fix catppuccin theme slider backgrounds

### DIFF
--- a/static/assets/css/themes/catppuccin/frappe.css
+++ b/static/assets/css/themes/catppuccin/frappe.css
@@ -34,7 +34,7 @@ button,
 }
 
 input:checked + .slider-round {
-   background-color: #000;
+   background-color: #00274C;
 }
 
 .f-nav-right .navbar-link {

--- a/static/assets/css/themes/catppuccin/latte.css
+++ b/static/assets/css/themes/catppuccin/latte.css
@@ -33,7 +33,7 @@ button,
 }
 
 input:checked + .slider-round {
-   background-color: #000;
+   background-color: #00274C;
 }
 
 .f-nav-right .navbar-link {

--- a/static/assets/css/themes/catppuccin/macchiato.css
+++ b/static/assets/css/themes/catppuccin/macchiato.css
@@ -34,7 +34,7 @@ button,
 }
 
 input:checked + .slider-round {
-   background-color: #000;
+   background-color: #00274C;
 }
 
 .f-nav-right .navbar-link {

--- a/static/assets/css/themes/catppuccin/mocha.css
+++ b/static/assets/css/themes/catppuccin/mocha.css
@@ -34,7 +34,7 @@ button,
 }
 
 input:checked + .slider-round {
-   background-color: #000;
+   background-color: #00274C;
 }
 
 .f-nav-right .navbar-link {


### PR DESCRIPTION
## Summary
- update catppuccin theme CSS so slider backgrounds are blue `#00274C`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e4aed83c8333b36008028f1fcd9d