### PR TITLE
Fix default background reset

### DIFF
--- a/static/assets/js/006.js
+++ b/static/assets/js/006.js
@@ -226,7 +226,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   resetButton.addEventListener("click", () => {
     localStorage.removeItem("backgroundImage");
-    document.body.style.backgroundImage = "url('default-background.jpg')";
+    document.body.style.backgroundImage =
+      "url('/assets/media/background/full-main.png')";
     window.location.reload();
   });
 });


### PR DESCRIPTION
## Summary
- use available background image when resetting the custom background

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef37912083338941c9e8825c50b8