### PR TITLE
Allow config via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration
+# Copy this file to .env and adjust values as needed
+
+# Enable basic auth challenge. Accepts true/false
+CHALLENGE=false
+
+# Comma separated username:password pairs
+USERS=interstellar:password
+
+# Server listening port
+PORT=8080
+
+# Allowed origins for CORS (optional)
+TRUSTED_ORIGINS=localhost

--- a/config.js
+++ b/config.js
@@ -1,9 +1,26 @@
+import { config as loadEnv } from "dotenv";
+
+loadEnv();
+
+const envChallenge = process.env.CHALLENGE || "false";
+const challenge = ["true", "1", "yes"].includes(envChallenge.toLowerCase());
+
+let users = { interstellar: "password" };
+if (process.env.USERS) {
+  users = {};
+  for (const pair of process.env.USERS.split(",")) {
+    const [username, password] = pair.split(":");
+    if (username && password) {
+      users[username] = password;
+    }
+  }
+}
+
 const config = {
-  challenge: false, // Set to true if you want to enable password protection.
-  users: {
-    // You can add multiple users by doing username: 'password'.
-    interstellar: "password",
-  },
+  // Set to true if you want to enable password protection.
+  challenge,
+  // You can add multiple users by doing username: 'password'.
+  users,
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- load environment variables in `config.js`
- parse `CHALLENGE` and `USERS` env vars
- document config options in `.env.example`

## Testing
- `pnpm run format`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685307ab0b34833384546ba742f18796