### PR TITLE
Add .dockerignore for slimmer builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Exclude unnecessary files from Docker context
+.git
+.github
+.vscode
+
+# Ignore tests and markdown files
+tests/
+*.md
+
+# Ignore node_modules for production installs
+node_modules


### PR DESCRIPTION
## Summary
- keep Docker context small by ignoring Git metadata, IDE configs, tests, markdown docs and node modules

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685307a9cfe4833392c6cb69c73d8856