### PR TITLE
Switch Docker build to pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM node:bookworm-slim
 ENV NODE_ENV=production
 
+RUN corepack enable && corepack prepare pnpm@9.10.0 --activate
+
 WORKDIR /app
 
-COPY ["package.json", "./"]
+COPY package.json pnpm-lock.yaml ./
 
-RUN npm install
+RUN pnpm install --prod
 
 COPY . .
 
-CMD [ "node", "index.js" ]
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Summary
- use `corepack` to enable `pnpm`
- run `pnpm install --prod` during Docker build
- update start command to `pnpm start`

## Testing
- `npm test --silent`
- `pnpm start` *(manually stopped)*

------
https://chatgpt.com/codex/tasks/task_e_685307a881ac83339ccea0b9edc65a11