### PR TITLE
Add permissions.json for full agent access

### DIFF
--- a/permissions.json
+++ b/permissions.json
@@ -1,0 +1,10 @@
+{
+  "agents": {
+    "default": {
+      "read": true,
+      "write": true,
+      "modifyAllFiles": true,
+      "allowedPaths": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow default agent to read/write and modify all files by adding `permissions.json`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68530a5a8d988333ac1268689f1701d4