### PR TITLE
Add logDoIt helper and usage docs

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -1,2 +1,3 @@
 ## 2025-06-18
 - Created AGENT_LOG.md to track future agent-initiated changes.
+[2025-06-18T20:13:50.464Z] added logDoIt helper and README instructions

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ TRUSTED_ORIGINS	Comma list of allowed domains	localhost,example.com
 
 You can also create a .env file in the project root.
 
+## 📝 Task Logging
+
+Use `logDoIt.js` to record completed tasks. Example:
+
+```js
+import { logDoIt } from "./logDoIt.js";
+
+logDoIt("Describe what you did");
+```
+
+Each call appends a timestamped entry to `AGENT_LOG.md`.
+
+
 ⸻
 
 🛠 Developer Notes

--- a/logDoIt.js
+++ b/logDoIt.js
@@ -1,0 +1,6 @@
+import fs from "node:fs";
+
+export function logDoIt(message) {
+  const entry = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFileSync("AGENT_LOG.md", entry);
+}


### PR DESCRIPTION
## Summary
- add `logDoIt.js` helper for task logging
- document task logging usage in README
- log completion of this task in `AGENT_LOG.md`

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68531d6ce2ac8333b258d8d607068cbd