### PR TITLE
Align licensing to AGPL-3.0-or-later

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -1,2 +1,1 @@
-## 2025-06-18
-- Created AGENT_LOG.md to track future agent-initiated changes.
+[2025-06-18T20:13:02.811Z] Updated license to AGPL-3.0-or-later and documented in README.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+
+Starlancer - released under the GNU Affero General Public License
+Version 3 or (at your option) any later version.
+
                   GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/README.md
+++ b/README.md
@@ -101,4 +101,8 @@ Built with ✨ by Arjun + Codex.
 
 ---
 
+## License
+
+Starlancer is licensed under the **GNU Affero General Public License v3.0 or later**. See [LICENSE](./LICENSE) for more details.
+
 Let me know if you want to tailor it more for a specific use case (school bypass, AI CLI, etc.), or if you want to add badges, deployment buttons, or links to docs/demo videos.

--- a/logDoIt.js
+++ b/logDoIt.js
@@ -1,0 +1,6 @@
+import fs from "node:fs";
+
+export function logDoIt(message) {
+  const entry = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFileSync("AGENT_LOG.md", entry);
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "author": "InterstellarNetwork",
-  "license": "GPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@nebula-services/bare-server-node": "^2.0.4",
     "chalk": "^5.4.1",


### PR DESCRIPTION
## Summary
- add helper script to log agent tasks
- log license update
- update package.json to use AGPL-3.0-or-later
- clarify AGPL license in LICENSE file
- note chosen license in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68531d72691883339c3ffc3ec0758388