### PR TITLE
Fix fetch in tests for Node 16

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -1,2 +1,3 @@
 ## 2025-06-18
 - Created AGENT_LOG.md to track future agent-initiated changes.
+[2025-06-18T20:13:25.965Z] Added node-fetch fallback in tests and created logDoIt helper

--- a/logDoIt.js
+++ b/logDoIt.js
@@ -1,0 +1,6 @@
+import fs from "node:fs";
+
+export function logDoIt(message) {
+  const entry = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFileSync("AGENT_LOG.md", entry);
+}

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,6 +1,12 @@
-const { spawn } = require("child_process");
+const { spawn } = require("node:child_process");
 const PORT = 31337;
 let server;
+
+if (!global.fetch) {
+  global.fetch = (...args) =>
+    import("node-fetch").then(({ default: fetch }) => fetch(...args));
+}
+
 const fetch = global.fetch;
 jest.setTimeout(10000);
 


### PR DESCRIPTION
## Summary
- use `node-fetch` as a global `fetch` fallback in tests
- add `logDoIt.js` helper for logging agent actions
- update agent log with task entry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68531d6d7c2883339c6f6983a529eef6