### PR TITLE
Remove Google Analytics code

### DIFF
--- a/static/apps.html
+++ b/static/apps.html
@@ -43,19 +43,6 @@
   <div class="apps"></div>
   <script src="assets/js/002.js?v=001"></script>
   <script src="/assets/js/001.js?v=001"></script>
-  <!-- Google Tag Manager removed -->
-  <!--
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-WKJQ5QHQTJ1");
-  </script>
-  -->
 </body>
 
 </html>

--- a/static/games.html
+++ b/static/games.html
@@ -38,19 +38,6 @@
   <script src="./assets/mathematics/config.js?v=2025-04-15"></script>
   <script src="assets/js/003.js?v=000"></script>
   <script src="/assets/js/001.js?v=001"></script>
-  <!-- Google Tag Manager removed -->
-  <!--
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-WKJQ5QHQTJ1");
-  </script>
-  -->
 </body>
 
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -33,19 +33,6 @@
   <script src="./assets/mathematics/config.js?v=2025-04-15"></script>
   <script src="assets/js/003.js?v=000"></script>
   <script src="/assets/js/001.js?v=001"></script>
-  <!-- Google Tag Manager removed -->
-  <!--
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-WKJQ5QHQTJ1");
-  </script>
-  -->
 </body>
 
 </html>

--- a/static/settings.html
+++ b/static/settings.html
@@ -233,19 +233,6 @@
   </div>
   <script src="/assets/js/001.js?v=001"></script>
   <script src="/assets/js/006.js?v=000"></script>
-  <!-- Google Tag Manager removed -->
-  <!--
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-WKJQ5QHQTJ1");
-  </script>
-  -->
 </body>
 
 </html>

--- a/static/tabs.html
+++ b/static/tabs.html
@@ -64,19 +64,6 @@
   <script src="./assets/mathematics/bundle.js?v=2025-04-15"></script>
   <script src="./assets/mathematics/config.js?v=2025-04-15"></script>
   <script src="/assets/js/001.js?v=001"></script>
-  <!-- Google Tag Manager removed -->
-  <!--
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WKJQ5QHQTJ1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-WKJQ5QHQTJ1");
-  </script>
-  -->
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove Google Tag Manager scripts from static pages

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d0507d9083338c4e372ad315a80d