### PR TITLE
Restore rotating splash messages

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -5,3 +5,4 @@
 [2025-06-18T20:29:51.836Z] Rebrand the gui
 [2025-06-18T20:38:49.415Z] Update GUI shadow and round all buttons
 [2025-06-18T21:11:55.153Z] Removed ad-related scripts and added cleanup log message
+[2025-06-20T22:39:22.529Z] Update splash messages with GO BLUE and MADE BY ARJUN

--- a/static/assets/js/004.js
+++ b/static/assets/js/004.js
@@ -128,7 +128,7 @@ document.addEventListener("DOMContentLoaded", event => {
 const SplashT = [
   "Over 8 Million Users since 2023",
   "Fastest growing proxy server",
-  "Made by xBubbo",
+  "GO BLUE and MADE BY ARJUN",
   "Thanks for using the site",
   "Follow us on Tiktok (@useinterstellar)",
   "Subscribe to us on YouTube (@unblocking)",

--- a/static/index.html
+++ b/static/index.html
@@ -28,7 +28,7 @@
     </div>
   </div>
   <script src="assets/js/005.js?v=000"></script>
-  <script src="/assets/js/004.js?v=000"></script>
+  <script src="/assets/js/004.js?v=002"></script>
   <script src="./assets/mathematics/bundle.js?v=2025-04-15"></script>
   <script src="./assets/mathematics/config.js?v=2025-04-15"></script>
   <script src="assets/js/003.js?v=000"></script>


### PR DESCRIPTION
## Summary
- bring back rotating splash messages
- show `GO BLUE and MADE BY ARJUN` as a splash message
- bump `004.js` version

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855e149a4348333843c61b26e193a33